### PR TITLE
Create `.scala-steward.conf`

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,0 +1,5 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
+  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.1." },
+  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." }
+]


### PR DESCRIPTION
Replay of https://github.com/typelevel/steward/pull/7.

If repos need to pin additional artifacts they may want to use `+=` to add instead of overwriting the defaults.