### PR TITLE
Unleash Scala 3.2.x

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,5 +1,5 @@
 updates.pin = [
-  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
-  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.1." },
+  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.2." },
+  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.2." },
   { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." }
 ]


### PR DESCRIPTION
We'll need this for https://github.com/http4s/http4s/pull/6726, and soon Cats Effect 3.4.0.