### PR TITLE
Setup a flake steward

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -35,10 +35,10 @@ jobs:
           private_key: ${{ secrets.STEWARD_PRIVATE_KEY }}
 
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@36f1c474807d62363305dcec6fd9ea9ed642c114
+        uses: DeterminateSystems/update-flake-lock@v15
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          branch: update/flake-lock-${{ github.run_number }}
+          branch: update/flake-lock
           git-author-email: 106843772+http4s-steward[bot]@users.noreply.github.com
           git-author-name: http4s-steward[bot]
           git-committer-email: 106843772+http4s-steward[bot]@users.noreply.github.com

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,51 @@
+name: http4s Flake Steward
+
+on:
+  schedule:
+    - cron: '45 7 * * 2'
+  workflow_dispatch:
+
+jobs:
+  lockfile:
+    strategy:
+      matrix:
+        repo:
+          - http4s/http4s
+          - http4s/http4s-dom
+          - http4s/http4s-jetty
+          - http4s/http4s-servlet
+          - http4s/http4s-tomcat
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ matrix.repo }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: 207529
+          private_key: ${{ secrets.STEWARD_PRIVATE_KEY }}
+
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@36f1c474807d62363305dcec6fd9ea9ed642c114
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          branch: update/flake-lock-${{ github.run_number }}
+          git-author-email: 106843772+http4s-steward[bot]@users.noreply.github.com
+          git-author-name: http4s-steward[bot]
+          git-committer-email: 106843772+http4s-steward[bot]@users.noreply.github.com
+          git-committer-name: http4s-steward[bot]
+          pr-body: |
+            Automated changes by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.
+
+            ```
+            {{ env.GIT_COMMIT_MESSAGE }}
+            ```


### PR DESCRIPTION
1. So we don't have to copy the workflow to every repo (and keep it up-to-date).
2. So we can keep the powerful `STEWARD_PRIVATE_KEY` scoped to this repo, instead of the org.
