### PR TITLE
Remove blaze from flake steward

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         repo:
-          - http4s/blaze
           - http4s/http4s
           - http4s/http4s-curl
           - http4s/http4s-dom

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   lockfile:
     strategy:
+      fail-fast: false
       matrix:
         repo:
           - http4s/http4s


### PR DESCRIPTION
It can re-enroll after it is fixed.
- https://github.com/http4s/steward/actions/runs/4171566458/jobs/7221635528