### PR TITLE
Pin sbt-http4s-org

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,5 +1,6 @@
 updates.pin = [
   { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.3." },
   { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.3." },
-  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.18." }
+  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.18." },
+  { groupId = "org.http4s", artifactId="sbt-http4s-org", version = "0." }
 ]


### PR DESCRIPTION
Part of https://github.com/orgs/http4s/discussions/2.  The version that publishes to Central can be 1.0.