### PR TITLE
http4s-netty default branch to series/0.7

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -18,7 +18,7 @@
 - http4s/http4s-jetty:series/0.27
 - http4s/http4s-jetty:series/0.28
 - http4s/http4s-netty:main
-- http4s/http4s-netty:series/0.5
+- http4s/http4s-netty:series/0.7
 - http4s/http4s-otel4s
 - http4s/http4s-play-json
 - http4s/http4s-prometheus-metrics:main


### PR DESCRIPTION
series/0.5 will only receive backports from series/0.7 if needed going forward.