### PR TITLE
Add http4s as token owner in steward and flake workflows

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           client-id: 207529
           private-key: ${{ secrets.STEWARD_PRIVATE_KEY }}
+          owner: http4s
 
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28

--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           client-id: 207529
           private-key: ${{ secrets.STEWARD_PRIVATE_KEY }}
+          owner: http4s
 
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@ff09222640622d474d0d9f93c04aefedd125b187 # v2.92.0


### PR DESCRIPTION
The create-github-app-token workflow has tighter permissions by default than the tibdex one.  This is generally a good thing, but it needs access to the repos to open pull requests.