### PR TITLE
Pin sbt to 1.x

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,4 +1,5 @@
 updates.pin = [
   { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.3." },
-  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.3." }
+  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.3." },
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." },
 ]


### PR DESCRIPTION
At least until sbt-typelevel is compatible, and probably some plugins after that.